### PR TITLE
resolved: #9 Todo's id is hiding in landscape mode

### DIFF
--- a/hivelocity-ios-test/hivelocity-ios-test/ViewController.swift
+++ b/hivelocity-ios-test/hivelocity-ios-test/ViewController.swift
@@ -154,10 +154,10 @@ extension UIView {
         translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate(
             [
-                topAnchor.constraint(equalTo: superview.topAnchor),
-                leftAnchor.constraint(equalTo: superview.leftAnchor),
-                rightAnchor.constraint(equalTo: superview.rightAnchor),
-                bottomAnchor.constraint(equalTo: superview.bottomAnchor),
+                topAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.topAnchor),
+                leadingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.leadingAnchor),
+                trailingAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.trailingAnchor),
+                bottomAnchor.constraint(equalTo: superview.safeAreaLayoutGuide.bottomAnchor),
             ]
         )
     }


### PR DESCRIPTION
[Reason]
While setting constrain it did not consider safe area.

[Fix]
Use safeAreaLayoutGuide while setting constrain to table view.